### PR TITLE
增加浏览器左右边缘的判断

### DIFF
--- a/src/tip.js
+++ b/src/tip.js
@@ -53,16 +53,27 @@ define(function(require, exports, module) {
                 return;
             }
             var ap = this._originArrowPosition,
+                triggerOffset = this.get('trigger').offset(),
+
                 scrollTop = $(window).scrollTop(),
                 viewportHeight = $(window).outerHeight(),
                 elemHeight = this.element.height() + this.get('distance'),
-                triggerTop = this.get('trigger').offset().top,
+                triggerTop = triggerOffset.top,
                 triggerHeight = this.get('trigger').height(),
+
+                scrollLeft = $(window).scrollLeft(),
+                viewportWidth = $(window).outerWidth(),
+                elemWidth = this.element.width() + this.get("distance"),
+                triggerLeft = triggerOffset.left,
+                triggerWidth = this.get("trigger").width(),
+
                 arrowMap = {
                     '1': 5,
                     '5': 1,
                     '7': 11,
-                    '11': 7
+                    '11': 7,
+                    '2': 10,
+                    '10': 2
                 };
 
             if ((ap == 11 || ap == 1) &&
@@ -73,6 +84,12 @@ define(function(require, exports, module) {
                      (triggerTop < scrollTop + elemHeight)) {
                 // tip 溢出屏幕上方
                 this.set('arrowPosition', arrowMap[ap]);
+            } else if ((ap == 2) && triggerLeft < scrollLeft + elemWidth) {
+                // tip 溢出屏幕左方
+                this.set("arrowPosition", arrowMap[ap]);
+            } else if ((ap == 10) && triggerLeft + triggerWidth > scrollLeft + viewportWidth - elemWidth) {
+                // tip 溢出屏幕右方
+                this.set("arrowPosition", arrowMap[ap]);
             } else {
                 // 复原
                 this.set('arrowPosition', this._originArrowPosition);


### PR DESCRIPTION
想了解一下是不是故意不做左右边缘的判断：）

查看Tip的文档，当tip的内容比较长，而且tip比较接近于浏览器的右边缘，而tip又没有显式指定宽度，tip的内容会自动折行。如果直接计算的话计算出来的tip的长度是折行后的长度，导致改变tip的位置后，tip相对于trigger的位置不正确。

所以在arale/position又提了一个pull request [https://github.com/aralejs/position/pull/8](https://github.com/aralejs/position/pull/8)，来支持获取tip原来正确的宽度。
